### PR TITLE
chore(release): Initial commit of manifest data replication script

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ This utility (replicate_manifest_config.sh) should facilitate the copy of versio
 
  - How to use it:
  Here is the syntax:
- > /bin/bash replicate_manifest_config.sh <branch>/<environment>/manifest.json <target_manifest>
+ > /bin/bash replicate_manifest_config.sh &lt;branch>/&lt;environment>/manifest.json &lt;target_manifest>
 
  Example:
  > % /bin/bash ../gen3-release-utils/replicate_manifest_config.sh master/internalstaging.datastage.io/manifest.json gen3.datastage.io/manifest.json

--- a/README.md
+++ b/README.md
@@ -1,2 +1,14 @@
 # gen3-release-utils
 Gen3 release process automation tools
+
+
+# Manifest replication
+
+This utility (replicate_manifest_config.sh) should facilitate the copy of versions (including dictionary_url, etc.) between `manifest.json` files, i.e., improving the release process so it will be more automated & less error-prone.
+
+ - How to use it:
+ Here is the syntax:
+ > /bin/bash replicate_manifest_config.sh <branch>/<environment>/manifest.json <target_manifest>
+
+ Example:
+ > % /bin/bash ../gen3-release-utils/replicate_manifest_config.sh master/internalstaging.datastage.io/manifest.json gen3.datastage.io/manifest.json

--- a/replicate_manifest_config.sh
+++ b/replicate_manifest_config.sh
@@ -36,16 +36,17 @@ echo $versions | jq '.['\"${svc}\"']'
 for service in "${svcs[@]}"; do
   new_version=$(echo $versions | jq '.['\"${service}\"']' | sed 's#/#\\/#g')
   echo "applying version ${new_version} for ${service}"
-  sed -i '.bak' "s/    \"${service}\": \".*,/    \"${service}\": ${new_version}/" $tgt_manifest
+  sed -i '.bak' "s/    \"${service}\": \".*,/    \"${service}\": ${new_version},/" $tgt_manifest
   # TODO: Err check
 done
 
 # replace dictionary
 echo "applying new dictionary ${new_dict}..."
-sed -i ".bak" "s/    \"dictionary_url\": \".*/    \"dictionary_url\": \"${new_dict}\",/" ../gitops-qa/test_manifest.json
+sed -i ".bak" "s/    \"dictionary_url\": \".*/    \"dictionary_url\": ${new_dict},/" $tgt_manifest
 # TODO: err check
 
 # remove backup file (rely on git)
+echo "removing temp file..."
 rm -rfv ${tgt_manifest}.bak
 
 echo "done"

--- a/replicate_manifest_config.sh
+++ b/replicate_manifest_config.sh
@@ -1,0 +1,51 @@
+#!/bin/bash
+
+if [ "$1" == "-h" ] || [ "$1" == "--help" ] || [ "$#" -ne 2 ]; then
+  echo "------------------------------------------------------------------------------"
+  echo "Usage - replicate_manifest_config <source_manifest> <target_manifest>"
+  echo ""
+  echo "e.g., ./replicate_manifest_config.sh internalstaging.datastage.io/manifest.json gitops-qa/jenkins-dcp.planx-pla.net/manifest.json"
+  echo ""
+  echo "The script pulls data from a source manifest and replaces the versions & dictionary of the target manifest"
+  echo "-------------------------------------------------------------------------------"
+  exit 0;
+fi;
+
+svcs=(arborist fence indexd aws-es-proxy peregrine pidgin revproxy sheepdog portal fluentd spark tube manifestservice wts guppy sower hatchery ambassador)
+
+# TODO: add "ssjdispatcher" "quay.io/cdis/ssjdispatcher:master" when modifying DEV/QA manifests 
+
+# source manifest
+# e.g., internalstaging.datastage.io/manifest.json
+src_manifest="$1"
+echo "fetching source manifest from: https://raw.githubusercontent.com/uc-cdis/cdis-manifest/master/${src_manifest}"
+versions_and_dict=$(curl -s "https://raw.githubusercontent.com/uc-cdis/cdis-manifest/master/${src_manifest}" | jq '.versions, .global.dictionary_url')
+# TODO: Error check here...
+
+versions=$(echo "$versions_and_dict" | sed '$d')
+new_dict=$(echo "$versions_and_dict" | tail -n1 | sed 's#/#\\/#g')
+
+# target manifest
+tgt_manifest="$2"
+
+echo "testing"
+svc="aws-es-proxy"
+echo $versions | jq '.['\"${svc}\"']'
+
+# replace all versions
+for service in "${svcs[@]}"; do
+  new_version=$(echo $versions | jq '.['\"${service}\"']' | sed 's#/#\\/#g')
+  echo "applying version ${new_version} for ${service}"
+  sed -i '.bak' "s/    \"${service}\": \".*,/    \"${service}\": ${new_version}/" $tgt_manifest
+  # TODO: Err check
+done
+
+# replace dictionary
+echo "applying new dictionary ${new_dict}..."
+sed -i ".bak" "s/    \"dictionary_url\": \".*/    \"dictionary_url\": \"${new_dict}\",/" ../gitops-qa/test_manifest.json
+# TODO: err check
+
+# remove backup file (rely on git)
+rm -rfv ${tgt_manifest}.bak
+
+echo "done"


### PR DESCRIPTION
Automation to address the following ticket:
PXP-5126: Introduce automation to apply manifest.json changes (update versions / migrate from QA'ed envs)

Nowadays, the manifest.json update is very error-prone so we need to introduce some automation to facilitate the update of the versions. Ideally, we should migrate the versions of a `manifest.json` that corresponds to an environment that has been signed off by the QA team.

Next: We need to automatically update Jenkins / QA environments so they don't become outdated and impact the tests due to old service versions or dictionaries.