### PR TITLE
chore(qa): Add all sower jobs to the monthly release cycles

### DIFF
--- a/repo_list.txt
+++ b/repo_list.txt
@@ -12,6 +12,7 @@ pidgin
 data-portal
 sheepdog
 sower
+sower-jobs
 ssjdispatcher
 tube
 workspace-token-service


### PR DESCRIPTION
Currently only `sower` and `pelican-export` are in `2020.07`.
So we must add all the remaining sower jobs to the monthly release cycles:
from: https://github.com/uc-cdis/sower-jobs
```
quay.io/cdis/manifest-indexing
quay.io/cdis/get-dbgap-metadata
quay.io/cdis/metadata-manifest-ingestion
quay.io/cdis/download-indexd-manifest
```
