### PR TITLE
add default git token

### DIFF
--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -21,6 +21,5 @@ jobs:
         $HOME/.poetry/bin/poetry install
     - name: Test with pytest
       run: |
-        export GITHUB_TOKEN="MEH-123"
         cd gen3release-sdk/tests
         $HOME/.poetry/bin/poetry run pytest -vv

--- a/gen3release-sdk/gen3release/gith/git.py
+++ b/gen3release-sdk/gen3release/gith/git.py
@@ -11,7 +11,7 @@ logging.getLogger(__name__)
 
 class Git:
     def __init__(
-        self, repo, token, org="uc-cdis",
+        self, repo="cdis-manifest", token="MEH-123", org="uc-cdis",
     ):
         """
      Creates a Github utils object to perform various operations against the uc-cdis repos and its branches, pull requests, etc.


### PR DESCRIPTION
Jira Ticket: [PXP-xxxx](https://ctds-planx.atlassian.net/browse/PXP-xxxx)
- [ ] Remove this line if you've changed the title to (PXP-xxxx): <title>

Tool will often be used without performing pull requests. It is more convenient to the user to not have to set a GITHUB_TOKEN
environment variable if they will never make a pull request.

### New Features


### Breaking Changes


### Bug Fixes


### Improvements


### Dependency updates


### Deployment changes
<!-- This section should only contain important things devops should know when updating service versions. -->
