### PR TITLE
Fix: move task of pushing quay images to ECR before the task of creation of cdis-manifest PRs

### DIFF
--- a/gen3release-sdk/release_jiras.py
+++ b/gen3release-sdk/release_jiras.py
@@ -51,16 +51,16 @@ tasks = [
         "description": "Generate the release notes with this Jenkins job: https://jenkins.planx-pla.net/job/gen3-qa-monthly-release-notes-generator. The cdis-manifest PR is tailored manually and it should include release notes and known bugs files (the PR must be labeled with `doc-only`).",
     },
     {
-        "title": "9. Create cdis-manifest PRs for {}".format(release),
+        "title": "9. Pushing monthly release quay images to AWS ECR (as a backup)",
+        "description": "Kick off this job: https://jenkins.planx-pla.net/job/push-gen3-monthly-release-images-to-aws-ecr. Also double-check if the repos_list.txt is up-to-date.",
+    },
+    {
+        "title": "10. Create cdis-manifest PRs for {}".format(release),
         "description": "Kick off this job: https://jenkins.planx-pla.net/job/create-prs-for-all-monthly-release-envs/",
     },
     {
-        "title": "SHARED: 10. Follow up with PMs to merge the PRs of respective commons",
+        "title": "SHARED: 11. Follow up with PMs to merge the PRs of respective commons",
         "description": "The `automerge` label is applied automatically to all PRs, once the PM approves it, the changes will be automatically merged and deployed to the environment. The QA engineers should monitor the PRs in case of any CI check failures.",
-    },
-    {
-        "title": "11. Pushing monthly release quay images to AWS ECR (as a backup)",
-        "description": "Kick off this job: https://jenkins.planx-pla.net/job/push-gen3-monthly-release-images-to-aws-ecr. Also double-check if the repos_list.txt is up-to-date.",
     },
     {
         "title": "12. Mark the release as released",


### PR DESCRIPTION
Move task of pushing quay images to ECR before the task of creation of cdis-manifest PRs.