### PR TITLE
fix(user-migration): create folders to migrate between user.yamls in the same repo

### DIFF
--- a/gen3release-sdk/gen3release/env_cli.py
+++ b/gen3release-sdk/gen3release/env_cli.py
@@ -207,9 +207,15 @@ def users(args):
 
     try:
         logging.debug("cloning src repo: {}".format(src_gh_client.clone_url))
-        src_user_yaml_repo = srcgh.clone_repo(src_gh_client, src_repo_dir, workspace)
+        os.mkdir(workspace + "/source")
+        src_user_yaml_repo = srcgh.clone_repo(
+            src_gh_client, src_repo_dir, workspace + "/source"
+        )
         logging.debug("cloning tgt repo: {}".format(tgt_gh_client.clone_url))
-        tgt_user_yaml_repo = tgtgh.clone_repo(tgt_gh_client, tgt_repo_dir, workspace)
+        os.mkdir(workspace + "/target")
+        tgt_user_yaml_repo = tgtgh.clone_repo(
+            tgt_gh_client, tgt_repo_dir, workspace + "/target"
+        )
     except Exception as git_error:
         print("Something went wrong: {}".format(git_error))
         sys.exit(1)
@@ -234,7 +240,11 @@ def users(args):
     logging.info(f"branch name is {branch_name}")
 
     tgtgh.create_pull_request_user_yaml(
-        tgt_gh_client, src_user_yaml, target_user_yaml_path, pr_title, branch_name
+        tgt_gh_client,
+        "source/" + src_user_yaml,
+        target_user_yaml_path,
+        pr_title,
+        branch_name,
     )
     logging.info("PR created successfully!")
 


### PR DESCRIPTION
https://ctds-planx.atlassian.net/browse/PXP-7125

Turns out the tool is only working if the user.yamls sit in different repos.
Because the Python Github code is trying to clone the same repo twice when it tries to migrate the changes:

```
Something went wrong: '/home/jenkins/agent/workspace/gen3-migrate-user-yamls/gen3release-sdk/commons-users' exists and is not an empty directory
Build step 'Execute shell' marked build as failure
```

The solution is to create sub-folders (source and target) so the repo can be cloned in different locations.