### PR TITLE
chore(qa): Do not replace terraExportURL and sevenBridgesExportURL

### DIFF
--- a/gen3release-sdk/gen3release/config/env.py
+++ b/gen3release-sdk/gen3release/config/env.py
@@ -57,6 +57,11 @@ class Env:
                 "gaTrackingId": "GEN3_RELEASE_SDK_PLACEHOLDER",
                 "dataExplorerConfig": {
                     "terraExportURL": "GEN3_RELEASE_SDK_PLACEHOLDER",
+                    "sevenBridgesExportURL": "GEN3_RELEASE_SDK_PLACEHOLDER",
+                },
+                "fileExplorerConfig": {
+                    "terraExportURL": "GEN3_RELEASE_SDK_PLACEHOLDER",
+                    "sevenBridgesExportURL": "GEN3_RELEASE_SDK_PLACEHOLDER",
                 },
             },
             "fence-config-public.yaml": {


### PR DESCRIPTION
Stop promoting the terraExportURL and sevenBridgesExportURL parameters between environments.