### PR TITLE
fix(code-promotion): Do not copy the fence-public-config.yaml file

### DIFF
--- a/gen3release-sdk/gen3release/config/env.py
+++ b/gen3release-sdk/gen3release/config/env.py
@@ -64,15 +64,15 @@ class Env:
                     "sevenBridgesExportURL": "GEN3_RELEASE_SDK_PLACEHOLDER",
                 },
                 "components": {
-                "login": {
-                    "title": "GEN3_RELEASE_SDK_PLACEHOLDER",
+                    "login": {
+                        "title": "GEN3_RELEASE_SDK_PLACEHOLDER",
+                    },
+                    "footerLogos": [
+                        {
+                            "src": "GEN3_RELEASE_SDK_PLACEHOLDER",
+                        }
+                    ],
                 },
-                "footerLogos": [
-                    {
-                        "src": "GEN3_RELEASE_SDK_PLACEHOLDER",
-                    }
-                ]
-            }
             },
             "fence-config-public.yaml": {
                 "BASE_URL": "GEN3_RELEASE_SDK_PLACEHOLDER",
@@ -83,6 +83,8 @@ class Env:
                 "LOGIN_REDIRECT_WHITELIST": "GEN3_RELEASE_SDK_PLACEHOLDER",
             },
         }
+
+        self.files_to_ignore = ["fence-config-public.yaml"]
 
         self.params_to_set = {
             "manifest.json": {"guppy": {"indices": [], "config_index": ""}},

--- a/gen3release-sdk/gen3release/filesys/io_processing.py
+++ b/gen3release-sdk/gen3release/filesys/io_processing.py
@@ -228,6 +228,10 @@ def recursive_copy(srcEnv, tgtEnv, src, dst):
                     files_copied[src_filepath] = True
                     continue
 
+                if a_file in tgtEnv.files_to_ignore:
+                    logging.warn(f"Ignoring file [{a_file}] as per ignore list...")
+                    continue
+
                 # files mapped in environment_specific_params need special treatment
                 params_template = tgtEnv.environment_specific_params.get(a_file)
                 names_template = tgtEnv.params_to_set.get(a_file)


### PR DESCRIPTION
Evidence:
```
gen3release [fix/do_not_copy_fence_public_config●] % python env_cli.py copy -s ~/workspace/cdis-manifest/preprod.gen3.biodatacatalyst.nhlbi.nih.gov -e ~/workspace/cdis-manifest/staging.gen3.biodatacatalyst.nhlbi.nih.gov -pr "TESTING STAGING COPY" 2>&1 | grep -i ignore
2021-02-16 17:25:00,230 [WARNING] Ignoring file [fence-config-public.yaml] as per ignore list...
```