### PR TITLE
chore(release): Ignore the dashboard svc during code promotion

### DIFF
--- a/gen3release-sdk/gen3release/config/env.py
+++ b/gen3release-sdk/gen3release/config/env.py
@@ -64,15 +64,15 @@ class Env:
                     "sevenBridgesExportURL": "GEN3_RELEASE_SDK_PLACEHOLDER",
                 },
                 "components": {
-                "login": {
-                    "title": "GEN3_RELEASE_SDK_PLACEHOLDER",
+                    "login": {
+                        "title": "GEN3_RELEASE_SDK_PLACEHOLDER",
+                    },
+                    "footerLogos": [
+                        {
+                            "src": "GEN3_RELEASE_SDK_PLACEHOLDER",
+                        }
+                    ],
                 },
-                "footerLogos": [
-                    {
-                        "src": "GEN3_RELEASE_SDK_PLACEHOLDER",
-                    }
-                ]
-            }
             },
             "fence-config-public.yaml": {
                 "BASE_URL": "GEN3_RELEASE_SDK_PLACEHOLDER",
@@ -94,6 +94,7 @@ class Env:
             "arranger-dashboard",
             "arranger-adminapi",
             "aws-es-proxy",
+            "dashboard",
             "fluentd",
             "ambassador",
             "nb2",

--- a/gen3release-sdk/pyproject.toml
+++ b/gen3release-sdk/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "gen3release"
-version = "1.1"
+version = "1.2"
 description = "Gen3 Release Management SDK"
 authors = ["CTDS UChicago <cdis@uchicago.edu>"]
 packages = [


### PR DESCRIPTION
Sometimes this service is only configured in PROD and we don't want the code promotion automation to remove it.