### PR TITLE
chore(reliability): add awshelper to monthly ecr push cycle

### DIFF
--- a/repo_list.txt
+++ b/repo_list.txt
@@ -25,3 +25,4 @@ dcf-dataservice
 mariner
 ws-storage
 ACCESS-backend
+cloud-automation


### PR DESCRIPTION
The `awshelper` image will be pushed to AWS ECR every monthy through this job here: https://jenkins.planx-pla.net/job/push-gen3-monthly-release-images-to-aws-ecr/

```
  elif [ "$repo" == "cloud-automation" ]; then
      echo "Found a repo called cloud-automation"
      IMG_TO_PUSH="awshelper"
...
        tag="$RELEASE_VERSION"
        gen3 ecr update-policy gen3/$IMG_TO_PUSH
	gen3 ecr quay-sync $IMG_TO_PUSH $tag
```


This should improve the reliability on PROD environments if any pod that utilizes this sidecar bounces.

Related to: https://github.com/uc-cdis/cloud-automation/pull/1555