### PR TITLE
chore(code-promotion): Skip qa-covid19 noteboks

### DIFF
--- a/gen3release-sdk/gen3release/filesys/io_processing.py
+++ b/gen3release-sdk/gen3release/filesys/io_processing.py
@@ -210,7 +210,9 @@ def recursive_copy(srcEnv, tgtEnv, src, dst):
                     "/".join(curr_dir.split("/")[-2::])
                     == "qa-covid19.planx-pla.net/dashboard"
                 ):
-                    # skip this whole directory
+                    logging.warn(
+                        "skipping the whole qa-covid19.planx-pla.net/dashboard directory..."
+                    )
                     continue
 
                 logging.debug(


### PR DESCRIPTION
Avoiding this error here:
```
github.GithubException.GithubException: 403 {"message": 
"This API returns blobs up to 1 MB in size. The requested blob is too large to fetch via the API,
 but you can use the Git Data API to request blobs up to 100 MB in size.", 
"errors": 
[{"resource": "Blob", "field": "data", "code": "too_large"}], 
"documentation_url": "https://docs.github.com/rest/reference/repos#get-repository-content"}
```

Caused by this humongous file: `dashboard/Public/notebooks/CTP_testing.html`