### PR TITLE
chore(data-manifest-qa): Improve groovy for qa-bdcat-data-release-simple-manifest

### DIFF
--- a/jenkins-jobs/qa-bdcat-data-release-simple-manifest.groovy
+++ b/jenkins-jobs/qa-bdcat-data-release-simple-manifest.groovy
@@ -46,7 +46,7 @@ spec:
                   doGenerateSubmoduleConfigurations: false,
                   extensions: [[$class: 'RelativeTargetDirectory', relativeTargetDir: 'gen3sdk-python']],
                   submoduleCfg: [],
-                  userRemoteConfigs: [[credentialsId: 'PlanXCyborgUserJenkins', url: 'https://github.com/uc-cdis/cloud-automation.git']]
+                  userRemoteConfigs: [[credentialsId: 'PlanXCyborgUserJenkins', url: 'https://github.com/uc-cdis/gen3sdk-python.git']]
                 ])
                 // gen3-qa
                 checkout([
@@ -55,7 +55,7 @@ spec:
                   doGenerateSubmoduleConfigurations: false,
                   extensions: [[$class: 'RelativeTargetDirectory', relativeTargetDir: 'gen3-qa']],
                   submoduleCfg: [],
-                  userRemoteConfigs: [[credentialsId: 'PlanXCyborgUserJenkins2', url: 'https://github.com/uc-cdis/gen3sdk-python.git']]
+                  userRemoteConfigs: [[credentialsId: 'PlanXCyborgUserJenkins2', url: 'https://github.com/uc-cdis/gen3-qa.git']]
                 ])
             }
         }


### PR DESCRIPTION
Stop using a gist-hosted script and use a gen3-qa script instead.