### PR TITLE
fix(release): Access Backend quay repo reference needs to be renamed

### DIFF
--- a/jenkins-jobs/push-gen3-monthly-release-images-to-aws-ecr.sh
+++ b/jenkins-jobs/push-gen3-monthly-release-images-to-aws-ecr.sh
@@ -29,6 +29,9 @@ while IFS= read -r repo; do
   elif [ "$repo" == "gen3-fuse" ]; then
       echo "Found a repo called gen3-fuse"
       IMG_TO_PUSH="gen3fuse-sidecar"
+  elif [ "$repo" == "cloud-automation" ]; then
+      echo "Found a repo called cloud-automation"
+      IMG_TO_PUSH="awshelper"
   elif [ "$repo" == "sower-jobs" ]; then
       echo "iterate through list ['metadata-manifest-ingestion', 'get-dbgap-metadata', 'manifest-indexing', 'download-indexd-manifest']"
       sower_jobs=(metadata-manifest-ingestion get-dbgap-metadata manifest-indexing download-indexd-manifest)
@@ -53,13 +56,10 @@ while IFS= read -r repo; do
 
       # move to the next repo
       continue
-  elif [ "$repo" == "ws-storage" ]; then
-      echo "Skipping this one as it is not part of 2020.12"
-
-      # move to the next repo
-      continue
+  elif [ "$repo" == "ACCESS-backend" ]; then
+      echo "Found a repo called ACCESS-backend"
+      IMG_TO_PUSH="access-backend"
   fi
-
 
   tag="$RELEASE_VERSION"
   gen3 ecr update-policy gen3/$IMG_TO_PUSH


### PR DESCRIPTION
Quay image references are expressed in lower case. This change addresses the following error:
```
pushing ACCESS-backend img to AWS ECR...

An error occurred (InvalidParameterException) when calling the SetRepositoryPolicy operation: Invalid parameter at 'repositoryName' failed to satisfy constraint: 'must satisfy regular expression '(?:[a-z0-9]+(?:[._-][a-z0-9]+)*/)*[a-z0-9]+(?:[._-][a-z0-9]+)*''
```