### PR TITLE
choer(push-gen3-monthly-release-images-to-aws-ecr): Send slack notifications with the name of the failing image

### DIFF
--- a/jenkins-jobs/push-gen3-monthly-release-images-to-aws-ecr.sh
+++ b/jenkins-jobs/push-gen3-monthly-release-images-to-aws-ecr.sh
@@ -33,7 +33,7 @@ while IFS= read -r repo; do
   IMG_TO_PUSH="$repo"
   if [ "$repo" == "pelican" ]; then
       echo "Found a repo called pelican"
-      IMG_TO_PUSH="pelican-exportt"
+      IMG_TO_PUSH="pelican-export"
   elif [ "$repo" == "docker-nginx" ]; then
       echo "Found a repo called docker-nginx"
       IMG_TO_PUSH="nginx"


### PR DESCRIPTION
the change is to notify the `#gen3-qa-notification` channel when the image has failed and cannot be pushed to the AWS ECR