### PR TITLE
adding jenkins to services ignore list

### DIFF
--- a/gen3release-sdk/gen3release/config/env.py
+++ b/gen3release-sdk/gen3release/config/env.py
@@ -101,6 +101,7 @@ class Env:
             "ambassador",
             "nb2",
             "jupyterhub",
+            "jenkins",
         ]
 
         self.blocks_to_update = {


### PR DESCRIPTION
Adding `jenkins` to service_to_ignore list

this is done to avoid the change the version of the jenkins when running gen3-release automation