### PR TITLE
fix(release-automation): Capture name of the current branch

### DIFF
--- a/make_stable_and_tag.sh
+++ b/make_stable_and_tag.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+name_of_the_branch=$(git branch --show-current)
+
 if [[ "$name_of_the_branch" == "master" ]]; then
   echo "all good. proceed..."
 else


### PR DESCRIPTION
Capturing the name of the current branch to interrupt the automation if the jenkins job is not running out of master.