### PR TITLE
chore(release): Ignore audit-service when applying release versions to PRs

### DIFF
--- a/gen3release-sdk/gen3release/config/env.py
+++ b/gen3release-sdk/gen3release/config/env.py
@@ -95,6 +95,7 @@ class Env:
             "arranger",
             "arranger-dashboard",
             "arranger-adminapi",
+            "audit-service",
             "aws-es-proxy",
             "dashboard",
             "fluentd",


### PR DESCRIPTION
audit-service has no monthly release tagging, hence, we can't let the auto-PRs mutates its version.