### PR TITLE
fix(jira-automation): Set Work to be Completed by: Project Team

### DIFF
--- a/gen3release-sdk/release_jiras.py
+++ b/gen3release-sdk/release_jiras.py
@@ -99,7 +99,7 @@ COMPONENTS = [
 epic_dict = {
     "project": PROJECT_NAME,
     "customfield_10011": RELEASE_TITLE,
-    "customfield_10067": {"id": "10054", "value": "Product Team"},
+    "customfield_10067": {"id": "10055", "value": "Project Team"},
     "summary": RELEASE_TITLE,
     "description": "This epic comprises all the tasks releated to {}".format(
         RELEASE_TITLE
@@ -132,7 +132,7 @@ for task in tasks:
         "project": PROJECT_NAME,
         "summary": summary,
         "description": task["description"],
-        "customfield_10067": {"id": "10054", "value": "Product Team"},
+        "customfield_10067": {"id": "10055", "value": "Project Team"},
         "issuetype": {"name": "Story"},
         "components": COMPONENTS,
         "assignee": {"accountId": team_members[team_member_index]["id"]},


### PR DESCRIPTION
Monthly Release Epic + Tasks must have the custom field "Work to be Completed by:" set to "Project Team" to avoiding any misleading work tracking analysis for the Product Team.