### PR TITLE
chore(code-promotion): footerLogos should be identical between environments

### DIFF
--- a/gen3release-sdk/gen3release/config/env.py
+++ b/gen3release-sdk/gen3release/config/env.py
@@ -67,11 +67,6 @@ class Env:
                     "login": {
                         "title": "GEN3_RELEASE_SDK_PLACEHOLDER",
                     },
-                    "footerLogos": [
-                        {
-                            "src": "GEN3_RELEASE_SDK_PLACEHOLDER",
-                        }
-                    ],
                 },
             },
             "fence-config-public.yaml": {


### PR DESCRIPTION
Why are we setting footerLogos as an environment-specific parameter?
We should promote such change across all environments, right?