### PR TITLE
chore(release): Suppress code promotion for datadog parameter

### DIFF
--- a/gen3release-sdk/gen3release/config/env.py
+++ b/gen3release-sdk/gen3release/config/env.py
@@ -28,6 +28,7 @@ class Env:
                     "logs_bucket": "GEN3_RELEASE_SDK_PLACEHOLDER",
                     "sync_from_dbgap": "GEN3_RELEASE_SDK_PLACEHOLDER",
                     "useryaml_s3path": "GEN3_RELEASE_SDK_PLACEHOLDER",
+                    "dd_enabled": "GEN3_RELEASE_SDK_PLACEHOLDER",
                 },
                 "hatchery": {
                     "user-namespace": "GEN3_RELEASE_SDK_PLACEHOLDER",

--- a/gen3release-sdk/tests/test_env.py
+++ b/gen3release-sdk/tests/test_env.py
@@ -30,6 +30,7 @@ def test_load_environment_params(target_env):
             "logs_bucket": "some bucket",
             "sync_from_dbgap": "",
             "useryaml_s3path": "",
+            "dd_enabled": "",
         },
         "hatchery": {
             "user-namespace": "a namespace",


### PR DESCRIPTION
We promote all changes from preprod to PROD, hence we should make this `dd_enabled` parameter an environment-specific config as we shouldn't enable it in PREPROD due to cost implications.