### PR TITLE
fix(nightly-build): Set quay path to all sower-jobs images

### DIFF
--- a/jenkins-jobs/nightly-job-run.sh
+++ b/jenkins-jobs/nightly-job-run.sh
@@ -37,12 +37,13 @@ sowerConfigBlock=$(cat chicagoland.pandemicresponsecommons.org/manifest.json | j
 jq --argjson obj '{"sower": '"$sowerConfigBlock"'}' '. += $obj' < nightly.planx-pla.net/manifest.json-tmp > temp && mv temp nightly.planx-pla.net/manifest.json-tmp
 
 # set all sower jobs images to master
-sed -i 's/gen3\/pelican-export:\(.*\)/gen3\/pelican-export:master",/' nightly.planx-pla.net/manifest.json-tmp
-sed -i 's/gen3\/metadata-manifest-ingestion:\(.*\)/gen3\/metadata-manifest-ingestion:master",/' nightly.planx-pla.net/manifest.json-tmp
-sed -i 's/gen3\/get-dbgap-metadata:\(.*\)/gen3\/get-dbgap-metadata:master",/' nightly.planx-pla.net/manifest.json-tmp
-sed -i 's/gen3\/manifest-indexing:\(.*\)/gen3\/manifest-indexing:master",/' nightly.planx-pla.net/manifest.json-tmp
-sed -i 's/gen3\/manifest-merging:\(.*\)/gen3\/manifest-merging:master",/' nightly.planx-pla.net/manifest.json-tmp
-sed -i 's/gen3\/download-indexd-manifest:\(.*\)/gen3\/download-indexd-manifest:master",/' nightly.planx-pla.net/manifest.json-tmp
+# with the quay img path as latest-master imgs are not automatically pushed to ECR
+sed -i 's/\(.*\)\/gen3\/pelican-export:\(.*\)/quay.io\/cdis\/pelican-export:master",/' nightly.planx-pla.net/manifest.json-tmp
+sed -i 's/\(.*\)\/gen3\/metadata-manifest-ingestion:\(.*\)/quay.io\/cdis\/metadata-manifest-ingestion:master",/' nightly.planx-pla.net/manifest.json-tmp
+sed -i 's/\(.*\)\/gen3\/get-dbgap-metadata:\(.*\)/quay.io\/cdis\/get-dbgap-metadata:master",/' nightly.planx-pla.net/manifest.json-tmp
+sed -i 's/\(.*\)\/gen3\/manifest-indexing:\(.*\)/quay.io\/cdis\/manifest-indexing:master",/' nightly.planx-pla.net/manifest.json-tmp
+sed -i 's/\(.*\)\/gen3\/manifest-merging:\(.*\)/quay.io\/cdis\/manifest-merging:master",/' nightly.planx-pla.net/manifest.json-tmp
+sed -i 's/\(.*\)\/gen3\/download-indexd-manifest:\(.*\)/quay.io\/cdis\/download-indexd-manifest:master",/' nightly.planx-pla.net/manifest.json-tmp
 
 guppyConfigBlock=$(cat chicagoland.pandemicresponsecommons.org/manifest.json | jq -r .guppy)
 jq --argjson obj '{"guppy": '"$guppyConfigBlock"'}' '. += $obj' < nightly.planx-pla.net/manifest.json-tmp > temp && mv temp nightly.planx-pla.net/manifest.json-tmp

--- a/jenkins-jobs/nightly-job-run.sh
+++ b/jenkins-jobs/nightly-job-run.sh
@@ -38,12 +38,12 @@ jq --argjson obj '{"sower": '"$sowerConfigBlock"'}' '. += $obj' < nightly.planx-
 
 # set all sower jobs images to master
 # with the quay img path as latest-master imgs are not automatically pushed to ECR
-sed -i 's/\(.*\)\/gen3\/pelican-export:\(.*\)/quay.io\/cdis\/pelican-export:master",/' nightly.planx-pla.net/manifest.json-tmp
-sed -i 's/\(.*\)\/gen3\/metadata-manifest-ingestion:\(.*\)/quay.io\/cdis\/metadata-manifest-ingestion:master",/' nightly.planx-pla.net/manifest.json-tmp
-sed -i 's/\(.*\)\/gen3\/get-dbgap-metadata:\(.*\)/quay.io\/cdis\/get-dbgap-metadata:master",/' nightly.planx-pla.net/manifest.json-tmp
-sed -i 's/\(.*\)\/gen3\/manifest-indexing:\(.*\)/quay.io\/cdis\/manifest-indexing:master",/' nightly.planx-pla.net/manifest.json-tmp
-sed -i 's/\(.*\)\/gen3\/manifest-merging:\(.*\)/quay.io\/cdis\/manifest-merging:master",/' nightly.planx-pla.net/manifest.json-tmp
-sed -i 's/\(.*\)\/gen3\/download-indexd-manifest:\(.*\)/quay.io\/cdis\/download-indexd-manifest:master",/' nightly.planx-pla.net/manifest.json-tmp
+sed -i 's/\(.*\)"image":\(.*\)\/gen3\/pelican-export:\(.*\)/\1"image": "quay.io\/cdis\/pelican-export:master",/' nightly.planx-pla.net/manifest.json-tmp
+sed -i 's/\(.*\)"image":\(.*\)\/gen3\/metadata-manifest-ingestion:\(.*\)/\1"image": "quay.io\/cdis\/metadata-manifest-ingestion:master",/' nightly.planx-pla.net/manifest.json-tmp
+sed -i 's/\(.*\)"image":\(.*\)\/gen3\/get-dbgap-metadata:\(.*\)/\1"image": "quay.io\/cdis\/get-dbgap-metadata:master",/' nightly.planx-pla.net/manifest.json-tmp
+sed -i 's/\(.*\)"image":\(.*\)\/gen3\/manifest-indexing:\(.*\)/\1"image": "quay.io\/cdis\/manifest-indexing:master",/' nightly.planx-pla.net/manifest.json-tmp
+sed -i 's/\(.*\)"image":\(.*\)\/gen3\/manifest-merging:\(.*\)/\1"image": "quay.io\/cdis\/manifest-merging:master",/' nightly.planx-pla.net/manifest.json-tmp
+sed -i 's/\(.*\)"image":\(.*\)\/gen3\/download-indexd-manifest:\(.*\)/\1"image": "quay.io\/cdis\/download-indexd-manifest:master",/' nightly.planx-pla.net/manifest.json-tmp
 
 guppyConfigBlock=$(cat chicagoland.pandemicresponsecommons.org/manifest.json | jq -r .guppy)
 jq --argjson obj '{"guppy": '"$guppyConfigBlock"'}' '. += $obj' < nightly.planx-pla.net/manifest.json-tmp > temp && mv temp nightly.planx-pla.net/manifest.json-tmp


### PR DESCRIPTION
The latest sower job master images are not pushed to AWS ECR automatically, hence we need to make sure the nightly build tests the latest latest master images published to Quay.