### PR TITLE
chore(nightly-job-run.sh): remove braincommons

### DIFF
--- a/jenkins-jobs/nightly-job-run.sh
+++ b/jenkins-jobs/nightly-job-run.sh
@@ -19,7 +19,7 @@ urlPrefix="https://${GITHUB_USERNAME}:${GITHUB_TOKEN}@github.com/uc-cdis/"
 git clone "${urlPrefix}cdis-manifest"
 cd cdis-manifest
 
-commons=("gen3.theanvil.io" "chicagoland.pandemicresponsecommons.org" "gen3.biodatacatalyst.nhlbi.nih.gov" "nci-crdc.datacommons.io" "data.braincommons.org" "vpodc.org")
+commons=("gen3.theanvil.io" "chicagoland.pandemicresponsecommons.org" "gen3.biodatacatalyst.nhlbi.nih.gov" "nci-crdc.datacommons.io" "vpodc.org")
 
 # Select from one randomly
 # TODO: We should cycle through each of them every night (TBD) -- This will pollute the cdis-manifest PRs screen so we should also .. CLOSE the PRs through a morning job :D


### PR DESCRIPTION
<!--
Make sure to follow the DEV guidelines (https://gen3.org/resources/developer/dev-introduction/) before asking for review.

- Describe what this pull request does.
- Add short descriptive bullet points for each section if relevant. Keep in mind that they will be parsed automatically to generate official release notes.
- Test manually.
- Maintain or increase the test coverage (if relevant).
- Update the documentation, or justify if not needed.

-->

data.braincommons.org [no longer exists](https://github.com/uc-cdis/cdis-manifest/pull/3122)

### Bug Fixes
- Remove data.braincommons.org from list of commons that the nightly job run selects from
