### PR TITLE
fix option in jwt decode

### DIFF
--- a/jenkins-jobs/check_credential_expire.py
+++ b/jenkins-jobs/check_credential_expire.py
@@ -16,7 +16,7 @@ def main():
     if os.path.exists(credential_filepath):
         credential = open(credential_filepath)
         api_key = json.load(credential)["api_key"]
-        expire_timestamp = jwt.decode(api_key, options={"verify_signature": False})[
+        expire_timestamp = jwt.decode(api_key, verify=False)[
             "exp"
         ]
         expire_datetime = datetime.fromtimestamp(expire_timestamp)


### PR DESCRIPTION
Only PyJWT >= v2.0 supports `options={"verify_signature": False}`
In jenkins, pyjwt version is 1.7.1, so it should use 
`decoded = jwt.decode(token, verify=False)  # works in PyJWT < v2.0`