### PR TITLE
chore(better-release): New script to iterate through all img names and apply new monthly release tag

### DIFF
--- a/jenkins-jobs/apply-new-monthly-release-tag-to-all-imgs.groovy
+++ b/jenkins-jobs/apply-new-monthly-release-tag-to-all-imgs.groovy
@@ -1,0 +1,39 @@
+/*
+  String parameter RELEASE_VERSION
+    e.g., 2021.04
+*/
+
+// Read the contents of repo_list.txt
+String fileContents = new File('repo_list.txt').getText('UTF-8')
+
+List<String> repos = Arrays.asList(LIST_OF_REPOS_WHOSE_IMAGES_NEED_TO_BE_TAGGED.split("\n"));
+
+def quietPeriod = 0;
+def jenkins = Jenkins.getInstance()
+def job = jenkins.getItem("quay-apply-new-tag-to-img");
+
+// TODO: create string containing integration202110 based on string 2021.10
+def currentImg = RELEASE_VERSION
+
+repos.each {githubRepoName ->
+  // TODO:
+  // Some repo names do not match the quay img name :( we need to convert them
+  def quayRepoName = ""
+
+  if githubRepoName == "pelican" {
+     quayRepoName = "pelican-export"
+  }
+
+  println "Applying new image tag ${RELEASE_VERSION} to current img ${}...";
+
+  def params = []
+
+  params += new StringParameterValue("LOAD_TEST_DESCRIPTOR", loadTestScenario);
+
+  params += new StringParameterValue("TARGET_ENVIRONMENT", "qa-dcp");
+  params += new StringParameterValue("PRESIGNED_URL_ACL_FILTER", "QA");
+
+  def paramsAction = new ParametersAction(params);
+  hudson.model.Hudson.instance.queue.schedule(job, quietPeriod, null, paramsAction);
+  quietPeriod += 1;
+}

--- a/jenkins-jobs/apply-new-monthly-release-tag-to-all-imgs.groovy
+++ b/jenkins-jobs/apply-new-monthly-release-tag-to-all-imgs.groovy
@@ -117,8 +117,8 @@ pipeline {
                         quietPeriod += 1;
                       }
                     }
-                  }
                 }
+              }
             }
         }
     }

--- a/jenkins-jobs/apply-new-monthly-release-tag-to-all-imgs.groovy
+++ b/jenkins-jobs/apply-new-monthly-release-tag-to-all-imgs.groovy
@@ -37,9 +37,9 @@ pipeline {
                     sh "ls -ilh ${env.WORKSPACE}/gen3-release-utils"
 
                     // Read the contents of repo_list.txt
-                    String fileContents = readFile "${env.WORKSPACE}/gen3-release-utils/repo_list.txt"
+                    String repoListFileContents = readFile "${env.WORKSPACE}/gen3-release-utils/repo_list.txt"
 
-                    List<String> repos = Arrays.asList(LIST_OF_REPOS_WHOSE_IMAGES_NEED_TO_BE_TAGGED.split("\n"));
+                    List<String> repos = Arrays.asList(repoListFileContents.split("\n"));
 
                     def quietPeriod = 0;
                     def jenkins = Jenkins.getInstance()

--- a/jenkins-jobs/apply-new-monthly-release-tag-to-all-imgs.groovy
+++ b/jenkins-jobs/apply-new-monthly-release-tag-to-all-imgs.groovy
@@ -3,12 +3,12 @@
     e.g., 2021.04
 */
 
-// debug current folder path
-def currPath = System.getProperty("user.dir");
-println("### ## current path: ${currPath}");
+def build = Thread.currentThread().executable
+
+println("### ## current path: ${build.workspace.toString()}");
 
 // Read the contents of repo_list.txt
-String fileContents = new File('./repo_list.txt').getText('UTF-8')
+String fileContents = new File("${build.workspace.toString()}/repo_list.txt").getText('UTF-8')
 
 List<String> repos = Arrays.asList(LIST_OF_REPOS_WHOSE_IMAGES_NEED_TO_BE_TAGGED.split("\n"));
 

--- a/jenkins-jobs/apply-new-monthly-release-tag-to-all-imgs.groovy
+++ b/jenkins-jobs/apply-new-monthly-release-tag-to-all-imgs.groovy
@@ -3,8 +3,6 @@
     e.g., 2021.04
 */
 
-def build = Thread.currentThread().executable
-
 println("### ## current path: ${build.workspace.toString()}");
 
 // Read the contents of repo_list.txt

--- a/jenkins-jobs/apply-new-monthly-release-tag-to-all-imgs.groovy
+++ b/jenkins-jobs/apply-new-monthly-release-tag-to-all-imgs.groovy
@@ -3,6 +3,10 @@
     e.g., 2021.04
 */
 
+// debug current folder path
+def currPath = System.getProperty("user.dir");
+println("### ## current path: ${currPath}");
+
 // Read the contents of repo_list.txt
 String fileContents = new File('./repo_list.txt').getText('UTF-8')
 

--- a/jenkins-jobs/apply-new-monthly-release-tag-to-all-imgs.groovy
+++ b/jenkins-jobs/apply-new-monthly-release-tag-to-all-imgs.groovy
@@ -35,7 +35,7 @@ pipeline {
                     println("### ## current path: ${env.WORKSPACE}");
 
                     // Read the contents of repo_list.txt
-                    String fileContents = new File("${env.WORKSPACE}/repo_list.txt").getText('UTF-8')
+                    String fileContents = new File("${env.WORKSPACE}/gen3-release-utils/repo_list.txt").getText('UTF-8')
 
                     List<String> repos = Arrays.asList(LIST_OF_REPOS_WHOSE_IMAGES_NEED_TO_BE_TAGGED.split("\n"));
 

--- a/jenkins-jobs/apply-new-monthly-release-tag-to-all-imgs.groovy
+++ b/jenkins-jobs/apply-new-monthly-release-tag-to-all-imgs.groovy
@@ -34,7 +34,7 @@ pipeline {
                 script {
                     println("### ## current path: ${env.WORKSPACE}");
 
-                    sh '''ls -Rilha'''
+                    sh "ls -ilh ${env.WORKSPACE}/gen3-release-utils"
 
                     // Read the contents of repo_list.txt
                     String fileContents = new File("${env.WORKSPACE}/gen3-release-utils/repo_list.txt").getText('UTF-8')

--- a/jenkins-jobs/apply-new-monthly-release-tag-to-all-imgs.groovy
+++ b/jenkins-jobs/apply-new-monthly-release-tag-to-all-imgs.groovy
@@ -34,6 +34,8 @@ pipeline {
                 script {
                     println("### ## current path: ${env.WORKSPACE}");
 
+                    sh '''ls -Rilha'''
+
                     // Read the contents of repo_list.txt
                     String fileContents = new File("${env.WORKSPACE}/gen3-release-utils/repo_list.txt").getText('UTF-8')
 

--- a/jenkins-jobs/apply-new-monthly-release-tag-to-all-imgs.groovy
+++ b/jenkins-jobs/apply-new-monthly-release-tag-to-all-imgs.groovy
@@ -4,7 +4,7 @@
 */
 
 // Read the contents of repo_list.txt
-String fileContents = new File('repo_list.txt').getText('UTF-8')
+String fileContents = new File('./repo_list.txt').getText('UTF-8')
 
 List<String> repos = Arrays.asList(LIST_OF_REPOS_WHOSE_IMAGES_NEED_TO_BE_TAGGED.split("\n"));
 

--- a/jenkins-jobs/apply-new-monthly-release-tag-to-all-imgs.groovy
+++ b/jenkins-jobs/apply-new-monthly-release-tag-to-all-imgs.groovy
@@ -15,8 +15,21 @@ pipeline {
                 cleanWs()
             }
         }
+        stage('Initial setup') {
+            steps {
+                // gen3-release-utils
+                checkout([
+                  $class: 'GitSCM',
+                  branches: [[name: 'refs/heads/master']],
+                  doGenerateSubmoduleConfigurations: false,
+                  extensions: [[$class: 'RelativeTargetDirectory', relativeTargetDir: 'gen3-release-utils']],
+                  submoduleCfg: [],
+                  userRemoteConfigs: [[credentialsId: 'PlanXCyborgUserJenkins', url: 'https://github.com/uc-cdis/gen3-release-utils.git']]
+                ])
+        }
         stage('Iterate through all repos, find their img names and apply new tag') {
             steps {
+              dir("gen3-release-utils") {
                 script {
                     println("### ## current path: ${env.WORKSPACE}");
 
@@ -104,6 +117,7 @@ pipeline {
                         quietPeriod += 1;
                       }
                     }
+                  }
                 }
             }
         }

--- a/jenkins-jobs/apply-new-monthly-release-tag-to-all-imgs.groovy
+++ b/jenkins-jobs/apply-new-monthly-release-tag-to-all-imgs.groovy
@@ -3,89 +3,109 @@
     e.g., 2021.04
 */
 
-println("### ## current path: ${env.WORKSPACE}");
-
-// Read the contents of repo_list.txt
-String fileContents = new File("${env.WORKSPACE}/repo_list.txt").getText('UTF-8')
-
-List<String> repos = Arrays.asList(LIST_OF_REPOS_WHOSE_IMAGES_NEED_TO_BE_TAGGED.split("\n"));
-
-def quietPeriod = 0;
-def jenkins = Jenkins.getInstance()
-def job = jenkins.getItem("quay-apply-new-tag-to-img");
-
-year = RELEASE_VERSION.split("\\.")[0]
-month = RELEASE_VERSION.split("\\.")[1]
-currentImg = "integration${year}${month}"
-
-reposAndImageNames = [
-    "pelican": "pelican-export",
-    "docker-nginx": "nginx",
-    "gen3-fuse": "gen3fuse-sidecar",
-    "cloud-automation": "awshelper",
-    "dataguids.org": "dataguids",
-]
-
-repos.each{ githubRepoName ->
-  imgName = githubRepoName
-  if (reposAndImageNames.containsKey(githubRepoName)) {
-    imgName = reposAndImageNames[githubRepoName];
-    println "Applying new image tag ${RELEASE_VERSION} to img ${imgName}...";
-
-    def params = []
-
-    params += new StringParameterValue("SERVICE_NAME", imgName);
-    params += new StringParameterValue("CURRENT_IMG_TAG", currentImg);
-    params += new StringParameterValue("NEW_IMG_TAG", RELEASE_VERSION);
-
-    def paramsAction = new ParametersAction(params);
-    hudson.model.Hudson.instance.queue.schedule(job, quietPeriod, null, paramsAction);
-    quietPeriod += 1;
-  }
-  else if (githubRepoName == "sower-jobs") {
-    sowerJobsImages=['metadata-manifest-ingestion', 'get-dbgap-metadata', 'manifest-indexing', 'download-indexd-manifest']
-
-    sowerJobsImages.each{ sowerJobsImg ->
-      println "Applying new image tag ${RELEASE_VERSION} to img from repo ${sowerJobsImg}...";
-
-      def params = []
-
-      params += new StringParameterValue("SERVICE_NAME", imgName);
-      params += new StringParameterValue("CURRENT_IMG_TAG", currentImg);
-      params += new StringParameterValue("NEW_IMG_TAG", RELEASE_VERSION);
-
-      def paramsAction = new ParametersAction(params);
-      hudson.model.Hudson.instance.queue.schedule(job, quietPeriod, null, paramsAction);
-      quietPeriod += 1;
+pipeline {
+    agent {
+      node {
+        label 'gen3-qa-worker'
+      }
     }
-  }
-  else if (githubRepoName == "mariner") {
-    marinerImages=['mariner-engine', 'mariner-s3sidecar', 'mariner-server']
+    stages {
+        stage('Clean old workspace') {
+            steps {
+                cleanWs()
+            }
+        }
+        stage('Iterate through all repos, find their img names and apply new tag') {
+            steps {
+                script {
+                    println("### ## current path: ${env.WORKSPACE}");
 
-    marinerImages.each{ marinerImg ->
-      println "Applying new image tag ${RELEASE_VERSION} to img from repo ${marinerImg}...";
+                    // Read the contents of repo_list.txt
+                    String fileContents = new File("${env.WORKSPACE}/repo_list.txt").getText('UTF-8')
 
-      def params = []
+                    List<String> repos = Arrays.asList(LIST_OF_REPOS_WHOSE_IMAGES_NEED_TO_BE_TAGGED.split("\n"));
 
-      params += new StringParameterValue("SERVICE_NAME", imgName);
-      params += new StringParameterValue("CURRENT_IMG_TAG", currentImg);
-      params += new StringParameterValue("NEW_IMG_TAG", RELEASE_VERSION);
+                    def quietPeriod = 0;
+                    def jenkins = Jenkins.getInstance()
+                    def job = jenkins.getItem("quay-apply-new-tag-to-img");
 
-      def paramsAction = new ParametersAction(params);
-      hudson.model.Hudson.instance.queue.schedule(job, quietPeriod, null, paramsAction);
-      quietPeriod += 1;
+                    year = RELEASE_VERSION.split("\\.")[0]
+                    month = RELEASE_VERSION.split("\\.")[1]
+                    currentImg = "integration${year}${month}"
+
+                    reposAndImageNames = [
+                        "pelican": "pelican-export",
+                        "docker-nginx": "nginx",
+                        "gen3-fuse": "gen3fuse-sidecar",
+                        "cloud-automation": "awshelper",
+                        "dataguids.org": "dataguids",
+                    ]
+
+                    repos.each{ githubRepoName ->
+                      imgName = githubRepoName
+                      if (reposAndImageNames.containsKey(githubRepoName)) {
+                        imgName = reposAndImageNames[githubRepoName];
+                        println "Applying new image tag ${RELEASE_VERSION} to img ${imgName}...";
+
+                        def params = []
+
+                        params += new StringParameterValue("SERVICE_NAME", imgName);
+                        params += new StringParameterValue("CURRENT_IMG_TAG", currentImg);
+                        params += new StringParameterValue("NEW_IMG_TAG", RELEASE_VERSION);
+
+                        def paramsAction = new ParametersAction(params);
+                        hudson.model.Hudson.instance.queue.schedule(job, quietPeriod, null, paramsAction);
+                        quietPeriod += 1;
+                      }
+                      else if (githubRepoName == "sower-jobs") {
+                        sowerJobsImages=['metadata-manifest-ingestion', 'get-dbgap-metadata', 'manifest-indexing', 'download-indexd-manifest']
+
+                        sowerJobsImages.each{ sowerJobsImg ->
+                          println "Applying new image tag ${RELEASE_VERSION} to img from repo ${sowerJobsImg}...";
+
+                          def params = []
+
+                          params += new StringParameterValue("SERVICE_NAME", imgName);
+                          params += new StringParameterValue("CURRENT_IMG_TAG", currentImg);
+                          params += new StringParameterValue("NEW_IMG_TAG", RELEASE_VERSION);
+
+                          def paramsAction = new ParametersAction(params);
+                          hudson.model.Hudson.instance.queue.schedule(job, quietPeriod, null, paramsAction);
+                          quietPeriod += 1;
+                        }
+                      }
+                      else if (githubRepoName == "mariner") {
+                        marinerImages=['mariner-engine', 'mariner-s3sidecar', 'mariner-server']
+
+                        marinerImages.each{ marinerImg ->
+                          println "Applying new image tag ${RELEASE_VERSION} to img from repo ${marinerImg}...";
+
+                          def params = []
+
+                          params += new StringParameterValue("SERVICE_NAME", imgName);
+                          params += new StringParameterValue("CURRENT_IMG_TAG", currentImg);
+                          params += new StringParameterValue("NEW_IMG_TAG", RELEASE_VERSION);
+
+                          def paramsAction = new ParametersAction(params);
+                          hudson.model.Hudson.instance.queue.schedule(job, quietPeriod, null, paramsAction);
+                          quietPeriod += 1;
+                        }
+                      } else {
+                        println "Applying new image tag ${RELEASE_VERSION} to img ${imgName}...";
+
+                        def params = []
+
+                        params += new StringParameterValue("SERVICE_NAME", imgName);
+                        params += new StringParameterValue("CURRENT_IMG_TAG", currentImg);
+                        params += new StringParameterValue("NEW_IMG_TAG", RELEASE_VERSION);
+
+                        def paramsAction = new ParametersAction(params);
+                        hudson.model.Hudson.instance.queue.schedule(job, quietPeriod, null, paramsAction);
+                        quietPeriod += 1;
+                      }
+                    }
+                }
+            }
+        }
     }
-  } else {
-    println "Applying new image tag ${RELEASE_VERSION} to img ${imgName}...";
-
-    def params = []
-
-    params += new StringParameterValue("SERVICE_NAME", imgName);
-    params += new StringParameterValue("CURRENT_IMG_TAG", currentImg);
-    params += new StringParameterValue("NEW_IMG_TAG", RELEASE_VERSION);
-
-    def paramsAction = new ParametersAction(params);
-    hudson.model.Hudson.instance.queue.schedule(job, quietPeriod, null, paramsAction);
-    quietPeriod += 1;
-  }
 }

--- a/jenkins-jobs/apply-new-monthly-release-tag-to-all-imgs.groovy
+++ b/jenkins-jobs/apply-new-monthly-release-tag-to-all-imgs.groovy
@@ -3,10 +3,10 @@
     e.g., 2021.04
 */
 
-println("### ## current path: ${WORKSPACE}");
+println("### ## current path: ${env.WORKSPACE}");
 
 // Read the contents of repo_list.txt
-String fileContents = new File("${WORKSPACE}/repo_list.txt").getText('UTF-8')
+String fileContents = new File("${env.WORKSPACE}/repo_list.txt").getText('UTF-8')
 
 List<String> repos = Arrays.asList(LIST_OF_REPOS_WHOSE_IMAGES_NEED_TO_BE_TAGGED.split("\n"));
 

--- a/jenkins-jobs/apply-new-monthly-release-tag-to-all-imgs.groovy
+++ b/jenkins-jobs/apply-new-monthly-release-tag-to-all-imgs.groovy
@@ -37,7 +37,7 @@ pipeline {
                     sh "ls -ilh ${env.WORKSPACE}/gen3-release-utils"
 
                     // Read the contents of repo_list.txt
-                    String fileContents = new File("${env.WORKSPACE}/gen3-release-utils/repo_list.txt").getText('UTF-8')
+                    String fileContents = readFile "${env.WORKSPACE}/gen3-release-utils/repo_list.txt"
 
                     List<String> repos = Arrays.asList(LIST_OF_REPOS_WHOSE_IMAGES_NEED_TO_BE_TAGGED.split("\n"));
 

--- a/jenkins-jobs/apply-new-monthly-release-tag-to-all-imgs.groovy
+++ b/jenkins-jobs/apply-new-monthly-release-tag-to-all-imgs.groovy
@@ -26,6 +26,7 @@ pipeline {
                   submoduleCfg: [],
                   userRemoteConfigs: [[credentialsId: 'PlanXCyborgUserJenkins', url: 'https://github.com/uc-cdis/gen3-release-utils.git']]
                 ])
+            }
         }
         stage('Iterate through all repos, find their img names and apply new tag') {
             steps {

--- a/jenkins-jobs/apply-new-monthly-release-tag-to-all-imgs.groovy
+++ b/jenkins-jobs/apply-new-monthly-release-tag-to-all-imgs.groovy
@@ -3,10 +3,10 @@
     e.g., 2021.04
 */
 
-println("### ## current path: ${build.workspace.toString()}");
+println("### ## current path: ${WORKSPACE}");
 
 // Read the contents of repo_list.txt
-String fileContents = new File("${build.workspace.toString()}/repo_list.txt").getText('UTF-8')
+String fileContents = new File("${WORKSPACE}/repo_list.txt").getText('UTF-8')
 
 List<String> repos = Arrays.asList(LIST_OF_REPOS_WHOSE_IMAGES_NEED_TO_BE_TAGGED.split("\n"));
 

--- a/jenkins-jobs/create-gen3-release-candidate-branch.sh
+++ b/jenkins-jobs/create-gen3-release-candidate-branch.sh
@@ -5,9 +5,8 @@
 # String parameter RELEASE_VERSION
 #   Default value: 2021.06
 
-export GITHUB_USERNAME="themarcelor"
+# GITHUB_USERNAME obtained from Jenkins Credentials
 # GITHUB_TOKEN obtained from Jenkins Credentials
-
 
 BRANCH_NAME=""
 if [[ $RELEASE_VERSION =~ [0-9]{4}\.([0-9]{2}) ]]; then


### PR DESCRIPTION
We should RE-LABEL `integration<yyyy>.<mm>` images with the monthly release tag to avoid non-deterministic build issues (e.g., accidentally absorb some 3rd party lib and releasing an image that does not reflect what we have been testing throughout the monthly release testing cycle).

This new script will orchestrate multiple calls to the https://jenkins.planx-pla.net/job/quay-apply-new-tag-to-img/ job by iterating through all the image names according to the repos declared in `repo_list.txt`