### PR TITLE
add gen3-release label when PR is created

### DIFF
--- a/gen3release-sdk/gen3release/gith/git.py
+++ b/gen3release-sdk/gen3release/gith/git.py
@@ -155,6 +155,7 @@ class Git:
         the_pr = github_client.create_pull(
             title=pr_title, body=commit_msg, head=branch_name, base="master"
         )
+        the_pr.add_to_labels("gen3-release")
 
     def create_pull_request_copy(
         self, github_client, tgtEnv, modified_files, pr_title, commit_msg, branch_name


### PR DESCRIPTION
apply `gen3-release` labels to PR while creating PR for integration branch testing