### PR TITLE
chore(nightly-job-run.sh): update vpodc.data-commons.org

### DIFF
--- a/jenkins-jobs/nightly-job-run.sh
+++ b/jenkins-jobs/nightly-job-run.sh
@@ -19,7 +19,7 @@ urlPrefix="https://${GITHUB_USERNAME}:${GITHUB_TOKEN}@github.com/uc-cdis/"
 git clone "${urlPrefix}cdis-manifest"
 cd cdis-manifest
 
-commons=("gen3.theanvil.io" "chicagoland.pandemicresponsecommons.org" "gen3.biodatacatalyst.nhlbi.nih.gov" "nci-crdc.datacommons.io" "vpodc.org")
+commons=("gen3.theanvil.io" "chicagoland.pandemicresponsecommons.org" "gen3.biodatacatalyst.nhlbi.nih.gov" "nci-crdc.datacommons.io" "vpodc.data-commons.org")
 
 # Select from one randomly
 # TODO: We should cycle through each of them every night (TBD) -- This will pollute the cdis-manifest PRs screen so we should also .. CLOSE the PRs through a morning job :D


### PR DESCRIPTION


### New Features


### Breaking Changes


### Bug Fixes
vpodc.org is now called vpodc.data-commons.org, updated

### Improvements


### Dependency updates


### Deployment changes
<!-- This section should only contain important things devops should know when updating service versions. -->
