### PR TITLE
updated nightly build run 

### DIFF
--- a/jenkins-jobs/nightly-job-run.sh
+++ b/jenkins-jobs/nightly-job-run.sh
@@ -19,7 +19,7 @@ urlPrefix="https://${GITHUB_USERNAME}:${GITHUB_TOKEN}@github.com/uc-cdis/"
 git clone "${urlPrefix}cdis-manifest"
 cd cdis-manifest
 
-commons=("gen3.theanvil.io" "chicagoland.pandemicresponsecommons.org" "gen3.biodatacatalyst.nhlbi.nih.gov" "nci-crdc.datacommons.io" "vpodc.data-commons.org")
+commons=("gen3.theanvil.io" "chicagoland.pandemicresponsecommons.org" "gen3.biodatacatalyst.nhlbi.nih.gov" "vpodc.data-commons.org")
 
 # Select from one randomly
 # TODO: We should cycle through each of them every night (TBD) -- This will pollute the cdis-manifest PRs screen so we should also .. CLOSE the PRs through a morning job :D


### PR DESCRIPTION
Updated nightly run by removing nci-crdc.datacommons.io commons. The reason for not considering this commons is PFB Export test suite is failing and PFB export is not enabled in this commons. 

### New Features


### Breaking Changes


### Bug Fixes


### Improvements


### Dependency updates


### Deployment changes
<!-- This section should only contain important things devops should know when updating service versions. -->
