### PR TITLE
Fix/keep release note for each repo

### DIFF
--- a/jenkins-jobs/gen3-qa-monthly-release-notes-generator_scheduled.sh
+++ b/jenkins-jobs/gen3-qa-monthly-release-notes-generator_scheduled.sh
@@ -44,4 +44,4 @@ python3.8 -m pip install dist/${wheel_file} --user
 
 cd $WORKSPACE
 
-gen3release notes -v ${RELEASE_VERSION} -f gen3_release_notes.md manifest.json
+# gen3release notes -v ${RELEASE_VERSION} -f gen3_release_notes.md manifest.json

--- a/jenkins-jobs/gen3-qa-monthly-release-notes-generator_scheduled.sh
+++ b/jenkins-jobs/gen3-qa-monthly-release-notes-generator_scheduled.sh
@@ -44,4 +44,4 @@ python3.8 -m pip install dist/${wheel_file} --user
 
 cd $WORKSPACE
 
-# gen3release notes -v ${RELEASE_VERSION} -f gen3_release_notes.md manifest.json
+gen3release notes -v ${RELEASE_VERSION} -f gen3_release_notes.md manifest.json

--- a/jenkins-jobs/generate_release_notes.sh
+++ b/jenkins-jobs/generate_release_notes.sh
@@ -54,14 +54,14 @@ echo >> gen3_release_notes.md
 repo_list="repo_list.txt"
 while IFS= read -r repo; do
   echo "### Getting the release notes for repo ${repo} ###"
-  result=$(gen3git --repo "${repoOwner}/${repo}" --github-access-token "${githubAccessToken}" --from-date "${startDate}" gen --to-date "${endDate}" --markdown)
+  result=$(gen3git --repo "${repoOwner}/${repo}" --github-access-token "${githubAccessToken}" --from-date "${startDate}" gen --to-date "${endDate}" --file-name "${repo}_release_notes" --markdown)
   RC=$?
   if [ $RC -ne 0 ]; then
     echo "$result"
     exit 1
   fi
   if [[ $(wc -l < release_notes.md) -ge 3 ]]; then
-    cat release_notes.md
-    cat release_notes.md >> gen3_release_notes.md
+    cat "${repo}_release_notes.md"
+    cat "${repo}_release_notes.md" >> gen3_release_notes.md
   fi
 done < "$repo_list"

--- a/jenkins-jobs/generate_release_notes.sh
+++ b/jenkins-jobs/generate_release_notes.sh
@@ -60,7 +60,7 @@ while IFS= read -r repo; do
     echo "$result"
     exit 1
   fi
-  if [[ $(wc -l < release_notes.md) -ge 3 ]]; then
+  if [[ $(wc -l < "${repo}_release_notes.md") -ge 3 ]]; then
     cat "${repo}_release_notes.md"
     cat "${repo}_release_notes.md" >> gen3_release_notes.md
   fi


### PR DESCRIPTION
fix the issue when the release note of a repo is empty, it will duplicate the previous repo's release note