### PR TITLE
fixing the create-indexd-record

### DIFF
--- a/jenkins-jobs/gen3-run-load-tests.groovy
+++ b/jenkins-jobs/gen3-run-load-tests.groovy
@@ -208,7 +208,7 @@ pipeline {
                           create-indexd-records)
                               echo "Selected create indexd records"
                               # FOR INDEXD RECORDS CREATION
-                              mv "$ED_DEV_ENV_CREDS_JSON" credentials.json
+                              # mv "$ED_DEV_ENV_CREDS_JSON" credentials.json
                               sed -i 's/"num_of_records": 1000,/"num_of_records": $INDEXD_NUM_OF_RECORDS_TO_CREATE,/' load-testing/sample-descriptors/load-test-create-indexd-records.json
                               SELECTED_LOAD_TEST_DESCRIPTOR="load-test-create-indexd-records.json"
                               ;;

--- a/jenkins-jobs/gen3-run-load-tests.groovy
+++ b/jenkins-jobs/gen3-run-load-tests.groovy
@@ -111,6 +111,7 @@ pipeline {
                 withCredentials([
                   file(credentialsId: 'fence-google-app-creds-secret', variable: 'GOOGLE_APP_CREDS_JSON'),
                   file(credentialsId: 'qa-dcp-credentials-json', variable: 'QA_DCP_CREDS_JSON'),
+                  file(credentialsId: 'qa-dcp-credentials-indexing-json', variable: 'QA_DCP_CREDS_INDEXING_JSON'),
                   file(credentialsId: 'ed-dev-environment-credentials', variable: 'ED_DEV_ENV_CREDS_JSON'),
                   string(credentialsId: 'temporary-qa-dcp-long-living-access-token', variable: 'ACCESS_TOKEN'),
                   file(credentialsId: 'QA-NIAID-CRED', variable: 'QA_NIAID_CREDS'),
@@ -208,7 +209,7 @@ pipeline {
                           create-indexd-records)
                               echo "Selected create indexd records"
                               # FOR INDEXD RECORDS CREATION
-                              # mv "$ED_DEV_ENV_CREDS_JSON" credentials.json
+                              mv "$QA_DCP_CREDS_INDEXING_JSON" credentials.json
                               sed -i 's/"num_of_records": 1000,/"num_of_records": $INDEXD_NUM_OF_RECORDS_TO_CREATE,/' load-testing/sample-descriptors/load-test-create-indexd-records.json
                               SELECTED_LOAD_TEST_DESCRIPTOR="load-test-create-indexd-records.json"
                               ;;


### PR DESCRIPTION
Fixing the `create-indexd-record` load tests