### PR TITLE
Remove Automerge labelling mechanism

### DIFF
--- a/gen3release-sdk/gen3release/gith/git.py
+++ b/gen3release-sdk/gen3release/gith/git.py
@@ -90,7 +90,6 @@ class Git:
         the_pr = github_client.create_pull(
             title=pr_title, body=copy_commit, head=branch_name, base="master"
         )
-        the_pr.add_to_labels("automerge")
 
     def create_pull_request_release_notes(
         self,
@@ -120,7 +119,6 @@ class Git:
         the_pr = github_client.create_pull(
             title=pr_title, body=commit_msg, head=branch_name, base="master"
         )
-        the_pr.add_to_labels("automerge")
         the_pr.add_to_labels("doc-only")
 
     def create_pull_request_apply(


### PR DESCRIPTION
Removing automerge labelling when the PR is created for release_notes and useryaml PRs

Jira Ticket: [GQE-126](https://ctds-planx.atlassian.net/browse/GQE-126)


[GQE-126]: https://ctds-planx.atlassian.net/browse/GQE-126?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ